### PR TITLE
BODSDataExtractor.egg-info folder added to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ _test/
 .DS_Store
 *.pyc
 dist/
+BODSDataExtractor.egg-info/


### PR DESCRIPTION
Ensure folder with package metadata is not under git version control