### PR TITLE
CM - Data pull optimizations and refactoring

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 
 dependencies = [
     "pandas>=1.4.2"
-    ,"bods-client>=0.9.1"
+    ,"bods-client>=0.11.0"
     ,"protobuf==3.20"
     ,"lxml==4.9.1"
     ,"xmltodict==0.13.0"

--- a/src/BODSDataExtractor/extractor.py
+++ b/src/BODSDataExtractor/extractor.py
@@ -149,9 +149,9 @@ class TimetableExtractor:
 
     def _dataset_filetype(self, response_headers):
         """Determines the filetype of the dataset served up by a dataset url.
-        Returns None if file is not a zip or xml. Else returns '.zip' or '.xml'.
+        Returns None if it can't be determined.
         """
-        pattern = r'(\.zip|\.xml)'
+        pattern = r'(\.\w+)"'
         m = re.search(pattern, response_headers['Content-Disposition'])
         try:
             return m.group(1)
@@ -163,16 +163,17 @@ class TimetableExtractor:
         extracts the data into a Pandas dataframe."""
         response = requests.get(url)
         filetype = self._dataset_filetype(response.headers)
-        if not filetype:
-            print('Invalid dataset file found: "{filetype}", skipping...')
-            return
+
         if filetype == '.zip':
             print(f'Fetching zip file from {url}...')
             txc_df = self._extract_zip(response)
-        else:
+        elif filetype == '.xml':
             print(f'Fetching xml file from {url}...')
             xml = io.BytesIO(response.content)
             txc_df = self._extract_xml(response.url, xml)
+        else:
+            print(f'Invalid dataset file found: "{filetype}", skipping...')
+            return
 
         return txc_df
 

--- a/src/BODSDataExtractor/extractor.py
+++ b/src/BODSDataExtractor/extractor.py
@@ -58,12 +58,9 @@ class TimetableExtractor:
         if stop_level:
             self.generate_timetable()
 
-    def create_zip_level_timetable_df(self, response):
-
-        """This function takes the json api response file 
-        and returns it as a pandas dataframe"""      
-
-        return pd.DataFrame([vars(t_dataset) for t_dataset in response.results])
+    def create_zip_level_timetable_df(self, timetable_api_response):
+        """Returns BODS Timetable API results as a dataframe."""
+        return pd.DataFrame([vars(t_dataset) for t_dataset in timetable_api_response.results])
 
     def extract_dataset_level_atco_codes(self):
 

--- a/src/BODSDataExtractor/extractor.py
+++ b/src/BODSDataExtractor/extractor.py
@@ -110,15 +110,12 @@ class TimetableExtractor:
             print('No results returned from BODS Timetable API. Please check input parameters.')
             return
 
+        print(f"Metadata downloaded for {len(self.metadata['url'])} records, converting to dataframe...")
         self.metadata = self.create_zip_level_timetable_df(timetable_datasets)
-        print(f"metadata downloaded for {len(self.metadata['url'])} records, converting to dataframe...")
-  
-        print('appending filetypes...')
-        self.metadata['filetype'] = [TimetableExtractor.determine_file_type(self.metadata,x) for x in self.metadata['url']]
+        self.metadata['filetype'] = self.metadata['extension']
 
-        #limit to just bods compliant files if requested
         if self.bods_compliant == True:
-            self.metadata = self.metadata[self.metadata['bods_compliance']==True]
+            self.metadata = self.metadata[self.metadata['bods_compliance'] == True]
 
         #limit results to specific atco codes if requested
         if self.atco_code is not None:

--- a/src/BODSDataExtractor/extractor.py
+++ b/src/BODSDataExtractor/extractor.py
@@ -57,34 +57,6 @@ class TimetableExtractor:
 
         if stop_level:
             self.generate_timetable()
-        
-    def check_api_response(self, response, apiResponse):
-        
-        #initialise empty message to be appended to
-        message=""
-
-        
-        if apiResponse==False:
-     
-            if response.get("results")==[]:
-                
-                response={'status_code': 404, 'reason': '{"Empty Dataset, due to invalid "NOC" or "status" entered"}'}
-            else:
-                pass
-                
-            
-            #we are extracting the status code (key) and the reason (value) 
-            
-            #checking through items in the api response dictionary
-            for key,value in response.items():
-                content=str(key) +" : "+ str(value)
-                
-                message="\n"+message+str(content)+"\n"
-                
-            raise ValueError(message)
-            
-            
-        
 
     def create_zip_level_timetable_df(self, response):
 

--- a/src/BODSDataExtractor/extractor.py
+++ b/src/BODSDataExtractor/extractor.py
@@ -433,13 +433,11 @@ class TimetableExtractor:
         return full_table
 
     def analytical_timetable_data(self):
-
-        ''''
-        Uses a collection of extraction functions to extract data from within xml files. 
+        """Uses a collection of extraction functions to extract data from within xml files. 
         Some of these xml files are within zip files, and so these are processed differently.
         This extracted data is combined with the metadata of each file, and columns renamed to
-        yield analytical ready timetable data
-        '''
+        yield analytical ready timetable data.
+        """
 
         orig_cols = ['url', 'id', 'operator_name' ,'description', 'comment', 'status', 'dq_score', 'dq_rag', 'bods_compliance', 'filetype']
         txc_cols = ['URL', 'DatasetID', 'OperatorName','Description', 'Comment', 'Status', 'dq_score', 'dq_rag', 'bods_compliance', 'FileType']

--- a/src/BODSDataExtractor/extractor.py
+++ b/src/BODSDataExtractor/extractor.py
@@ -357,69 +357,20 @@ class TimetableExtractor:
         else:
             self.service_line_extract = self.service_line_extract_with_stop_level_json.drop(['la_code'],axis=1).drop_duplicates()
             self.check_for_expired_operators()
-        return self.service_line_extract
-
-
-
-    def expired_status(date, end_date, today):
-        """
-        Based on the expiry date, a boolean value is assigned to the 'expired' variable, this is
-        then returned back to the 'check_for_expired_operators' function.
-        """        
-        
-        expired=False
-        
-        #If the end date is greater or equal to today's date, if so expiry is False 
-        if end_date>=today:
-            expired=False
-                                       
-        #If the end date is less than today's date, if so expiry is True                               
-        elif end_date<today:
-            expired=True
-         
-        #If the date format is not recognised for the "end_date" the above conditions won't be set to true leaving us with an unknown expiry
-        else:
-            print("Date format not recognised, please check the dates in the 'OperatingPeriodEndDate' cloumn" )
-            
-        return(expired)
-            
+        return self.service_line_extract          
             
     def check_for_expired_operators(self):
-
+        """Adds service expiry status (True or False) to service level extract,
+        based on "OperatingPeriodEndDate" and today's date, where applicable.
+        If no end date provided then "No End Date" entered.
         """
-        Looks at the 'OperatingPeriodEndDate' column. For every date that's been entered, it 
-        is converted to a "datetime" object and passed on to the expired_status functiom to 
-        determine expiry . A new cloumn is then created and inserted after the OperatingPeriodEndDate 
-        column showing expiry status.
-        """
-        
-        expiredFlag = []
-        
-
-        
-        #convert operating date
-        if self.service_line_level == True:
-            for date in self.service_line_extract['OperatingPeriodEndDate']:
-                if date==None:
-                    expiredFlag.append("No End Date")
-                    continue
-                
-                #Clean Operating Period Date    
-                end_date= datetime.datetime.strptime(date,"%Y-%m-%d")
-                end_date=end_date.strftime("%Y-%m-%d")   
-                    
-                #Clean Today's Date
-                today=datetime.datetime.now()
-                today=today.strftime("%Y-%m-%d")
-                
-                    
-                expiredFlag.append(TimetableExtractor.expired_status(date,end_date,today))
-              
-        #Column is inserted after the operating end date column,        
-        self.service_line_extract.insert( loc=24, column="Expired_Operator", value=expiredFlag)
-        
-                            
-        return self.service_line_extract
+        today = datetime.datetime.now()
+        self.service_line_extract["Expired_Operator"] = (
+            pd.to_datetime(self.service_line_extract["OperatingPeriodEndDate"]) < today
+        )
+        self.service_line_extract.loc[
+            self.service_line_extract["OperatingPeriodEndDate"].isna(), "Expired_Operator"
+        ] = 'No End Date'
 
     def xplode(self, df, cols_to_explode):
         """Explode out lists in dataframes.

--- a/src/BODSDataExtractor/extractor.py
+++ b/src/BODSDataExtractor/extractor.py
@@ -85,8 +85,12 @@ class TimetableExtractor:
         params = timetables.TimetableParams(limit=self.limit,
                                             nocs=self.nocs,
                                             status=self.status,
-                                            admin_areas=self.atco_code,
                                             search=self.search)
+        """Below, handles bug with the BODS Timetable API. Bug will only use the last
+        admin area provided by the iterable. Converting to delimited string ensures
+        that all the admin_areas are used in the API query."""
+        if self.atco_code:
+            params.admin_areas = ','.join(self.atco_code)
         return bods.get_timetable_datasets(params=params)
 
     def pull_timetable_data(self):

--- a/src/BODSDataExtractor/extractor.py
+++ b/src/BODSDataExtractor/extractor.py
@@ -13,6 +13,7 @@ from itertools import zip_longest, product
 import numpy as np
 from pathlib import Path
 from sys import platform
+import re
 # try except ensures that this reads in lookup file whether pip installing the library, or cloning the repo from GitHub
 try:
     import BODSDataExtractor.otc_db_download as otc_db_download
@@ -145,6 +146,17 @@ class TimetableExtractor:
             print(f"*****Error in dataset. Please check filetype: {url}*****\n")
             TimetableExtractor.error_list.append(url)
             pass
+
+    def _dataset_filetype(self, response_headers):
+        """Determines the filetype of the dataset served up by a dataset url.
+        Returns None if file is not a zip or xml. Else returns '.zip' or '.xml'.
+        """
+        pattern = r'(\.zip|\.xml)'
+        m = re.search(pattern, response_headers['Content-Disposition'])
+        try:
+            return m.group(1)
+        except AttributeError:
+            return None
 
     def download_extract_zip(self, url):
         """Download a ZIP file and extract the relevant contents

--- a/src/BODSDataExtractor/extractor.py
+++ b/src/BODSDataExtractor/extractor.py
@@ -35,7 +35,7 @@ class TimetableExtractor:
 
     error_list = []
 
-    def __init__(self, api_key, limit=10000, nocs=None, status='published', search=None, bods_compliant=True, atco_code=None, service_line_level=False, stop_level=False, threaded=False):
+    def __init__(self, api_key, limit=10_000, nocs=None, status='published', search=None, bods_compliant=True, atco_code=None, service_line_level=False, stop_level=False, threaded=False):
         self.api_key = api_key
         self.limit = limit
         self.nocs = nocs
@@ -48,7 +48,7 @@ class TimetableExtractor:
         self.threaded = threaded
 
         self.pull_timetable_data()
-        
+
         if self.metadata is None:
             return # early return if no results to process
 
@@ -99,14 +99,14 @@ class TimetableExtractor:
     def pull_timetable_data(self):
         """Creates the timetable dataset metadata dataframe and assigns to
         self.metadata.
-        
+
         Will return early with self.metadata set to None if there
         are no datasets to work with.
         """
         print(f"Fetching timetable metadata for up to {self.limit:,} datasets...")
         timetable_datasets = self._get_timetable_datasets()
 
-        if timetable_datasets.count == 0 :
+        if timetable_datasets.count == 0:
             self.metadata = None
             print('No results returned from BODS Timetable API. Please check input parameters.')
             return

--- a/src/BODSDataExtractor/extractor.py
+++ b/src/BODSDataExtractor/extractor.py
@@ -43,32 +43,17 @@ class TimetableExtractor:
         self.atco_code = atco_code
         self.service_line_level = service_line_level
         self.stop_level = stop_level
+
         self.pull_timetable_data()
+        
         self.otc_db = otc_db_download.fetch_otc_db()
-        
-     
-        if service_line_level is True and stop_level is True:
+
+        if service_line_level or stop_level:
             self.analytical_timetable_data()
             self.analytical_timetable_data_analysis()
+
+        if stop_level:
             self.generate_timetable()
-        else:
-            pass
-            
-
-        if service_line_level is True and stop_level is False:
-            self.analytical_timetable_data()
-            self.analytical_timetable_data_analysis()
-        else:
-            pass
-
-        if stop_level is True and  service_line_level is False:
-            self.analytical_timetable_data()
-            self.analytical_timetable_data_analysis()
-            self.generate_timetable()
-
-        # self.service_line_extract = service_line_extract
-        
-        
         
     def check_api_response(self, response, apiResponse):
         

--- a/src/BODSDataExtractor/extractor.py
+++ b/src/BODSDataExtractor/extractor.py
@@ -421,20 +421,6 @@ class TimetableExtractor:
                             
         return self.service_line_extract
 
-
-
-    def zip_or_xml(self, extension, url):
-
-        """
-        Dictates which extraction function to use based on whether the downloaded
-        file from the BODS platform is an xml, or a zip file.
-        """
-
-        if extension == 'zip':
-            TimetableExtractor.download_extract_zip(self, url)
-        else:
-            TimetableExtractor.download_extract_xml(self, url)
-
     def xplode(self, df, cols_to_explode):
         """Explode out lists in dataframes.
         Taken from https://stackoverflow.com/a/61390677"""

--- a/src/BODSDataExtractor/extractor.py
+++ b/src/BODSDataExtractor/extractor.py
@@ -65,18 +65,6 @@ class TimetableExtractor:
 
         return pd.DataFrame([vars(t_dataset) for t_dataset in response.results])
 
-    def determine_file_type(self ,url):
-        '''downloads a file from a url and returns the extension'''
-
-        response = requests.head(url)
-        try:
-            filename = response.headers["Content-Disposition"].split('"')[1]
-            extension = filename.split('.')[-1]
-
-            return extension
-        except:
-            return 'error in filename'
-
     def extract_dataset_level_atco_codes(self):
 
         #initiate list for atco codes

--- a/src/BODSDataExtractor/extractor.py
+++ b/src/BODSDataExtractor/extractor.py
@@ -144,7 +144,7 @@ class TimetableExtractor:
 
     def download_extract_zip(self, url):
         """Download a ZIP file and extract the relevant contents
-        of each xml file within into a dataframe.
+        of each xml file into a dataframe.
         """
         print(f"Fetching zip file from {url} in metadata table...")
         output = []
@@ -167,10 +167,12 @@ class TimetableExtractor:
         return pd.concat(output)
 
     def download_extract_xml(self, url):
+        """Download the xml at the specified url, then extract into a dataframe."""
         xml = self._download_xml(url)
         return self._extract_xml(url, xml)
 
     def _download_xml(self, url):
+        """Download the xml from the specified URL."""
         print(f"Fetching xml file from {url} in metadata table...")
         resp = requests.get(url)
         xml = io.BytesIO(resp.content)

--- a/src/BODSDataExtractor/extractor.py
+++ b/src/BODSDataExtractor/extractor.py
@@ -28,8 +28,6 @@ from geopandas import GeoDataFrame
 import plotly.express as px
 import plotly.io as pio
 
-import sys
-
 class TimetableExtractor:
 
 

--- a/src/BODSDataExtractor/extractor.py
+++ b/src/BODSDataExtractor/extractor.py
@@ -199,65 +199,9 @@ class TimetableExtractor:
         return pd.concat(output)
 
     def _extract_xml(self, url, xml):
-        xml_output = []
-
-        #note the url
-        xml_output.append(url)
-
-        #create xml data object
-        xml_data = xmlDataExtractor(xml)
-
-        #extract data from xml 
-        filename = xmlDataExtractor.extract_filename(xml_data)
-        xml_output.append(filename)
-
-        noc = xmlDataExtractor.extract_noc(xml_data)
-        xml_output.append(noc)
-
-        trading_name = xmlDataExtractor.extract_trading_name(xml_data)
-        xml_output.append(trading_name)
-
-        licence_number = xmlDataExtractor.extract_licence_number(xml_data)
-        xml_output.append(licence_number)
-
-        operator_short_name = xmlDataExtractor.extract_operator_short_name(xml_data)
-        xml_output.append(operator_short_name)
-
-        operator_code = xmlDataExtractor.extract_operator_code(xml_data)
-        xml_output.append(operator_code)
-
-        service_code = xmlDataExtractor.extract_service_code(xml_data)
-        xml_output.append(service_code)
-
-        line_name = xmlDataExtractor.extract_line_name(xml_data)
-        xml_output.append(line_name)
-
-        public_use = xmlDataExtractor.extract_public_use(xml_data)
-        xml_output.append(public_use)
-
-        operating_days = xmlDataExtractor.extract_operating_days(xml_data)
-        xml_output.append(operating_days)
-
-        service_origin = xmlDataExtractor.extract_service_origin(xml_data)
-        xml_output.append(service_origin)
-
-        service_destination = xmlDataExtractor.extract_service_destination(xml_data)
-        xml_output.append(service_destination)
-
-        operating_period_start_date = xmlDataExtractor.extract_operating_period_start_date(xml_data)
-        xml_output.append(operating_period_start_date)
-
-        operating_period_end_date = xmlDataExtractor.extract_operating_period_end_date(xml_data)
-        xml_output.append(operating_period_end_date)
-
-        schema_version = xmlDataExtractor.extract_schema_version(xml_data)
-        xml_output.append(schema_version)
-
-        revision_number = xmlDataExtractor.extract_revision_number(xml_data)
-        xml_output.append(revision_number)
-
-        la_code = xmlDataExtractor.extract_la_code(xml_data)
-        xml_output.append(la_code)
+        xml_output = [url]
+        xml_data_extractor = xmlDataExtractor(xml)
+        xml_output.extend(xml_data_extractor.extract_service_level_info())
 
         # if stop level data is requested, then need the additional columns that contain jsons of the stop level info
         if self.stop_level == True:
@@ -1720,6 +1664,45 @@ class xmlDataExtractor:
     def __init__(self, filepath):
         self.root = ET.parse(filepath).getroot()
         self.namespace = self.root.nsmap
+
+    def extract_service_level_info(self):
+        filename = self.extract_filename()
+        noc = self.extract_noc()
+        trading_name = self.extract_trading_name()
+        licence_number = self.extract_licence_number()
+        operator_short_name = self.extract_operator_short_name()
+        operator_code = self.extract_operator_code()
+        service_code = self.extract_service_code()
+        line_name = self.extract_line_name()
+        public_use = self.extract_public_use()
+        operating_days = self.extract_operating_days()
+        service_origin = self.extract_service_origin()
+        service_destination = self.extract_service_destination()
+        operating_period_start_date = self.extract_operating_period_start_date()
+        operating_period_end_date = self.extract_operating_period_end_date()
+        schema_version = self.extract_schema_version()
+        revision_number = self.extract_revision_number()
+        la_code = self.extract_la_code()
+
+        return [
+            filename,
+            noc,
+            trading_name,
+            licence_number,
+            operator_short_name,
+            operator_code,
+            service_code,
+            line_name,
+            public_use,
+            operating_days,
+            service_origin,
+            service_destination,
+            operating_period_start_date,
+            operating_period_end_date,
+            schema_version,
+            revision_number,
+            la_code,
+        ]
 
     def extract_filename(self):
         

--- a/src/BODSDataExtractor/extractor.py
+++ b/src/BODSDataExtractor/extractor.py
@@ -108,13 +108,8 @@ class TimetableExtractor:
         params = timetables.TimetableParams(limit=self.limit,
                                             nocs=self.nocs,
                                             status=self.status,
+                                            admin_areas=self.atco_code,
                                             search=self.search)
-        """Below, handles bug with the BODS Timetable API. Bug will only use the last
-        admin area provided by the iterable. Converting to delimited string ensures
-        that all the admin_areas are used in the API query."""
-        if self.atco_code:
-            params.admin_areas = ','.join(self.atco_code)
-
         api_response = bods.get_timetable_datasets(params=params)
         return self._handle_api_response(api_response)
 

--- a/src/BODSDataExtractor/extractor.py
+++ b/src/BODSDataExtractor/extractor.py
@@ -331,34 +331,25 @@ class TimetableExtractor:
 # =============================================================================
         if self.atco_code is not None:
             self.service_line_extract_with_stop_level_json = self.service_line_extract_with_stop_level_json[self.service_line_extract_with_stop_level_json['la_code'].isin(self.atco_code)]
-        else:
-            pass
-
-        return self.service_line_extract_with_stop_level_json
-
 
     def analytical_timetable_data_analysis(self):
-
-        '''
-        Returns a copy of the service line level data suitable for analysis. Omits the columns with jsons
+        """Returns a copy of the service line level data suitable for analysis. Omits the columns with jsons
         of the final stop level data required for further processing and stop level analysis, for 
         performance and storage sake. Also omits la_code column, as if user is not interested in 
         local authorities of services then this adds unnecessary duplication (one service line can be in
         multiple las.)
+        """
+        self.service_line_extract = self.service_line_extract_with_stop_level_json.drop(
+            ["la_code"], axis=1
+        )
+        if self.stop_level:
+            self.service_line_extract_with_stop_level_json.drop(
+                ["journey_pattern_json", "vehicle_journey_json", "services_json"], axis=1
+            )
 
-        '''
+        self.service_line_extract = self.service_line_extract.drop_duplicates()
+        self.check_for_expired_operators()
 
-        #conditional logic required, as json cols dont exist if stop_level parameter != True
-
-        
-        if self.stop_level == True:
-            self.service_line_extract = self.service_line_extract_with_stop_level_json.drop(['journey_pattern_json','vehicle_journey_json','services_json','la_code'],axis=1).drop_duplicates()
-            self.check_for_expired_operators()
-        else:
-            self.service_line_extract = self.service_line_extract_with_stop_level_json.drop(['la_code'],axis=1).drop_duplicates()
-            self.check_for_expired_operators()
-        return self.service_line_extract          
-            
     def check_for_expired_operators(self):
         """Adds service expiry status (True or False) to service level extract,
         based on "OperatingPeriodEndDate" and today's date, where applicable.

--- a/src/BODSDataExtractor/extractor.py
+++ b/src/BODSDataExtractor/extractor.py
@@ -647,7 +647,7 @@ class TimetableExtractor:
         stop_level_df_journey = pd.DataFrame(stop_level_list_journey)
 
         #explode out lists in dataframe
-        stop_level_df_journey = TimetableExtractor.xplode(stop_level_df_journey,['JourneyPatternSectionID'
+        stop_level_df_journey = self.xplode(stop_level_df_journey,['JourneyPatternSectionID'
                                           ,"journey_pattern_timing_link"
                                           ,"stop_from"
                                           ,"stop_to"
@@ -696,7 +696,7 @@ class TimetableExtractor:
         stop_level_df_vehicle = pd.DataFrame(stop_level_list_vehicle)
 
         #explode out lists in dataframe
-        stop_level_df_vehicle = TimetableExtractor.xplode(stop_level_df_vehicle,[
+        stop_level_df_vehicle = self.xplode(stop_level_df_vehicle,[
                                             "VehicleJourneyCode"
                                             ,"JourneyPatternRef"
                                             ,"DepartureTime"
@@ -743,7 +743,7 @@ class TimetableExtractor:
         stop_level_df_vehicle = pd.DataFrame(stop_level_list_vehicle)
 
         #explode out lists in dataframe
-        stop_level_df_vehicle = TimetableExtractor.xplode(stop_level_df_vehicle,[
+        stop_level_df_vehicle = self.xplode(stop_level_df_vehicle,[
                                                 # "VehicleJourneyCode"
                                                 "JourneyPatternRef"
                                                 ,"LineRef"
@@ -794,7 +794,7 @@ class TimetableExtractor:
         stop_level_df_service = pd.DataFrame(stop_level_list_service)
 
         #explode out lists in dataframe
-        stop_level_df_service = TimetableExtractor.xplode(stop_level_df_service,['JourneyPattern_id', 'JourneyPatternSectionRef'])
+        stop_level_df_service = self.xplode(stop_level_df_service,['JourneyPattern_id', 'JourneyPatternSectionRef'])
         stop_level_df_service = stop_level_df_service.explode(['JourneyPatternSectionRef']).reset_index()
         del stop_level_df_service['index']
 

--- a/src/BODSDataExtractor/extractor.py
+++ b/src/BODSDataExtractor/extractor.py
@@ -158,6 +158,21 @@ class TimetableExtractor:
         except AttributeError:
             return None
 
+    def download_extract_txc(self, url):
+        """Download the txc data from a dataset url (can be zip or single xml) and
+        extracts the data into a Pandas dataframe."""
+        response = requests.get(url)
+        filetype = self._dataset_filetype(response.headers)
+        if not filetype:
+            print('Invalid dataset file found: "{filetype}", skipping...')
+            return
+        if filetype == '.zip':
+            print(f'Fetching zip file from {url}...')
+            self._extract_zip(response)
+        else:
+            print(f'Fetching xml file from {url}...')
+            self._extract_xml(response)
+
     def download_extract_zip(self, url):
         """Download a ZIP file and extract the relevant contents
         of each xml file into a dataframe.

--- a/src/BODSDataExtractor/extractor.py
+++ b/src/BODSDataExtractor/extractor.py
@@ -82,7 +82,7 @@ class TimetableExtractor:
         and returns the json output as a dataframe
         '''
 
-        print(f"Fetching timetable metadata for up to {self.limit} datasets...")
+        print(f"Fetching timetable metadata for up to {self.limit:,} datasets...")
         bods = BODSClient(api_key=self.api_key)
         params = timetables.TimetableParams(limit=self.limit,
                                             nocs=self.nocs,
@@ -102,7 +102,7 @@ class TimetableExtractor:
         if self.bods_compliant == True:
             self.metadata = self.metadata[self.metadata['bods_compliance'] == True]
 
-        print(f"Metadata downloaded for {len(self.metadata['url'])} records.")
+        print(f"Metadata downloaded for {self.metadata.shape[0]:,} datasets.")
 
     def xml_metadata(self, url, error_list):
 

--- a/src/BODSDataExtractor/extractor.py
+++ b/src/BODSDataExtractor/extractor.py
@@ -350,8 +350,9 @@ class TimetableExtractor:
         self.service_line_extract = self.service_line_extract_with_stop_level_json.drop(
             ["la_code"], axis=1
         )
+
         if self.stop_level:
-            self.service_line_extract_with_stop_level_json.drop(
+            self.service_line_extract = self.service_line_extract_with_stop_level_json.drop(
                 ["journey_pattern_json", "vehicle_journey_json", "services_json"], axis=1
             )
 

--- a/src/BODSDataExtractor/otc_db_download.py
+++ b/src/BODSDataExtractor/otc_db_download.py
@@ -68,7 +68,7 @@ def save_otc_db():
 
 def fetch_otc_db():
     """Returns a pandas dataframe of the OTC database (all regions combined)."""
-    print(f'Downloading OTC database...')
+    print('Downloading OTC database...')
     otc_regions = []
 
     for region in OTC_DB_FILES:


### PR DESCRIPTION
I've tried to keep the same logical flow but have optimized some aspects of the data pull -- however I have not looked at the timetable generation, as I am aware that that is having changes made to it. Generally this has been done with refactoring the code for logical or clarity reasons, utilizing more pythonic code styles, reducing repetition, removing redundant methods etc.

As an analyst for a local authority, I'm particularly keen (as I believe many consumers would be) on utilizing the package for area based queries (in my case, Leicester and Leicestershire admin areas). As such I have now improved the "pull_timetable_data" method to incorporate the atco_code at the Timetable API request level as opposed to filtering out the wanted services after downloading the whole dastaset. This change, saves a very, very large amount of time for my use case.

The other change is to include a `threaded` parameter to the TimetableExtractor `__init__()`. If set to to "True", then multithreading is used to significantly increase the dataset download time. Please see the two examples below for timings on my (not high-performance) laptop:

```python
# Executes in roughly 25 seconds, detailing just Leicester and Leicestershire services
TimetableExtractor(key, service_line_level=True, atco_codes=['260', '269'], threaded=True)

# Executes ~ 7 minutes, fetching all available datasets (963 timetable dataset at the time of writing).
TimetableExtractor(key, service_line_level=True, threaded=True)
```