### PR TITLE
Feature aa download folder specification

### DIFF
--- a/src/BODSDataExtractor/example.py
+++ b/src/BODSDataExtractor/example.py
@@ -7,22 +7,24 @@
 # All that is needed is to enter your api key in the variable 'api', and run the code!
 # =============================================================================
 
-try:
-  from BODSDataExtractor.extractor import TimetableExtractor
-except:
-  from extractor import TimetableExtractor
-  
+# try:
+#   from BODSDataExtractor.extractor import TimetableExtractor
+# except:
+#   from extractor import TimetableExtractor
+
+import extractor
 import os
 
 #retrieve api key from environment variables
-api = os.environ.get('api_key')
+api = os.environ.get('API')
+
 
 #-------------------------------------------
 #            FINE TUNED RESULTS
 #-------------------------------------------
 #intiate an object instance called my_bus_data_object with desired parameters 
 
-my_bus_data_object = TimetableExtractor(api_key=api
+my_bus_data_object = extractor.TimetableExtractor(api_key=api
                                  ,status = 'published' 
                                  ,service_line_level=True 
                                  ,stop_level=True 
@@ -45,8 +47,8 @@ my_bus_data_object.save_service_line_extract_to_csv()
 #save the extracted stop level data to stop_level variable
 stop_level = my_bus_data_object.timetable_dict
 
-#stop_level variable is a dictionary of dataframes, which can be saved to csv as follows (saves in downloads folder)
-my_bus_data_object.save_all_timetables_to_csv()
+#stop_level variable is a dictionary of dataframes, which can be saved to csv as follows (saves in downloads folder, if in_downloads_folder is False, saves in project folder)
+my_bus_data_object.save_all_timetables_to_csv(in_downloads_folder=False)
 
 #visualise a particular service line on an interactive map
 my_bus_data_object.visualise_service_line('PB0001746:3')
@@ -70,4 +72,3 @@ red_dq = my_bus_data_object.red_dq_scores() #returns the number of operators in 
 less_than_10 = my_bus_data_object.dq_less_than_x(90) # takes an integer as input (in this case 10) and returns a list of operators with a data quality score less than that integer
 
 no_lic_no = my_bus_data_object.no_licence_no() # returns a report listing which datasets contain files which do not have a licence number
-

--- a/src/BODSDataExtractor/example.py
+++ b/src/BODSDataExtractor/example.py
@@ -35,13 +35,13 @@ my_bus_data_object = extractor.TimetableExtractor(api_key=api
 #save the extracted dataset level data to filtered_dataset_level variable
 filtered_dataset_level = my_bus_data_object.metadata
 
-#save the extracted dataset level data to lcoal csv file
+#save the extracted dataset level data to local csv file
 my_bus_data_object.save_metadata_to_csv()
 
 #save the extracted service line level data to dataset_level variable
 filtered_service_line_level = my_bus_data_object.service_line_extract
 
-#save the extracted service line level data to lcoal csv file
+#save the extracted service line level data to local csv file
 my_bus_data_object.save_service_line_extract_to_csv()
 
 #save the extracted stop level data to stop_level variable

--- a/src/BODSDataExtractor/example.py
+++ b/src/BODSDataExtractor/example.py
@@ -16,7 +16,7 @@ import extractor
 import os
 
 #retrieve api key from environment variables
-api = os.environ.get('API')
+api = os.environ.get('api_key')
 
 
 #-------------------------------------------

--- a/src/BODSDataExtractor/extractor.py
+++ b/src/BODSDataExtractor/extractor.py
@@ -963,37 +963,37 @@ class TimetableExtractor:
     def get_user_downloads_folder(self):
         
         question = "Enter 'Y' to save to project folder or 'N' to save to downloads folder: "
-
+        
         choice = input(question)
         while choice not in ['y', 'Y', 'n', 'N']:
             print('Invalid choice')
             choice = input(question)
-
-
+        
+        
         if choice =="N" or choice=="n":
-
+            
             downloads_folder = str(os.path.join(Path.home(), "Downloads"))
-
+            
             if os.path.exists(downloads_folder):
                 print("Downloads Folder Located")
-
+            
             elif not os.path.exists(downloads_folder):
                 downloads_folder = str(Path.home() / "Downloads")
-
+                
             else:
                 print("Unrecognised OS, cannot locate downloads folder")
                 downloads_folder = ""
-
+            
         elif choice is choice=="y" or choice=="Y":
-
+            
             downloads_folder=str(os.path.dirname(os.path.abspath(__file__)))+"\Output"
-
+            
             if os.path.exists(downloads_folder):
                 print("Adding to Output Folder...")
-
+            
             elif not os.path.exists(downloads_folder):
                 os.makedirs('output')
-
+                
             else:
                 print("Uknown Error")
 

--- a/src/BODSDataExtractor/extractor.py
+++ b/src/BODSDataExtractor/extractor.py
@@ -958,11 +958,24 @@ class TimetableExtractor:
 
         print('Timetable generated!')
         return self.timetable_dict
+    
+    
+    def add_to_output_folder(self):
+        downloads_folder=str(os.path.dirname(os.path.abspath(__file__)))+"\Output"
+        
+        if os.path.exists(downloads_folder):
+            print("Adding to output Folder...")
+        
+        elif not os.path.exists(downloads_folder):
+            os.makedirs('output')
+            
+        else:
+            print("Uknown Error")
+            
+        return downloads_folder
 
 
     def get_user_downloads_folder(self, in_downloads_folder):
-        
-        
         
         if in_downloads_folder:
             
@@ -975,23 +988,14 @@ class TimetableExtractor:
                 downloads_folder = str(Path.home() / "Downloads")
                 
             else:
-                print("Unrecognised OS, cannot locate downloads folder")
-                downloads_folder = ""
+                print("Unrecognised OS, cannot locate downloads folder, saving to project folder")
+                downloads_folder=TimetableExtractor.add_to_output_folder(self)
             
         elif not in_downloads_folder:
-            
-            downloads_folder=str(os.path.dirname(os.path.abspath(__file__)))+"\Output"
-            
-            if os.path.exists(downloads_folder):
-                print("Adding to output Folder...")
-            
-            elif not os.path.exists(downloads_folder):
-                os.makedirs('output')
-                
-            else:
-                print("Uknown Error")
-
+            downloads_folder=TimetableExtractor.add_to_output_folder(self)
+        
         return downloads_folder
+
 
     def create_today_folder(self, in_downloads_folder):
         '''
@@ -1056,7 +1060,7 @@ class TimetableExtractor:
         metadata['localities'] = metadata['localities'].apply(lambda x: x[0:400])
 
         
-        destination = TimetableExtractor.create_today_folder(self)
+        destination = TimetableExtractor.create_today_folder(self, bool)
         metadata.to_csv(f'{destination}/metadata.csv', index=False)
 
 
@@ -1065,17 +1069,17 @@ class TimetableExtractor:
         Save service line table to csv file
         """
 
-        destination = TimetableExtractor.create_today_folder(self)
+        destination = TimetableExtractor.create_today_folder(self, bool)
         self.service_line_extract.to_csv(f'{destination}/service_line_extract.csv', index=False)
 
-    def save_all_timetables_to_csv(self, in_downloads_folder=True):
+    def save_all_timetables_to_csv(self, in_downloads_folder):
 
         '''
         Save all timetables from the timetable_dict attribute as local csv files.
         '''
 
         #create folder to save timetables int and get name of new folder
-        destination = TimetableExtractor.create_today_folder(self, in_downloads_folder)
+        destination = TimetableExtractor.create_today_folder(self,in_downloads_folder )
 
         for k,v in self.timetable_dict.items():
             print (f'writing {k} to csv...')
@@ -1084,8 +1088,7 @@ class TimetableExtractor:
             v.to_csv(f'{destination}/{k}_timetable.csv', index=False)
 
 
-    def save_filtered_timetables_to_csv(self, service_code, in_downloads_folder):
-        #downloads folder True or false 
+    def save_filtered_timetables_to_csv(self, service_code):
 
         '''
         Save a filtered subset of timetables from the timetable_dict attribute as local csv files.
@@ -1096,7 +1099,7 @@ class TimetableExtractor:
         '''
 
         #create folder to save timetables int and get name of new folder
-        destination = TimetableExtractor.create_today_folder(self, in_downloads_folder)
+        destination = TimetableExtractor.create_today_folder(self,bool)
 
 
         filtered_dict = TimetableExtractor.filter_timetable_dict(self, service_code)

--- a/src/BODSDataExtractor/extractor.py
+++ b/src/BODSDataExtractor/extractor.py
@@ -961,6 +961,9 @@ class TimetableExtractor:
 
 
     def get_user_downloads_folder(self):
+        '''
+        Specify where the output of stop level is saved, within the project folder or in the downloads folder
+        '''
         
         question = "Enter 'Y' to save to project folder or 'N' to save to downloads folder: "
         

--- a/src/BODSDataExtractor/extractor.py
+++ b/src/BODSDataExtractor/extractor.py
@@ -961,16 +961,41 @@ class TimetableExtractor:
 
 
     def get_user_downloads_folder(self):
-        if platform == "win32":
-            downloads_folder = str(Path.home() / "Downloads")
+        
+        question = "Enter 'Y' to save to project folder or 'N' to save to downloads folder: "
 
-        elif platform == "darwin" or "linux":
-            # for macOS or linux
+        choice = input(question)
+        while choice not in ['y', 'Y', 'n', 'N']:
+            print('Invalid choice')
+            choice = input(question)
+
+
+        if choice =="N" or choice=="n":
+
             downloads_folder = str(os.path.join(Path.home(), "Downloads"))
 
-        else:
-            print("Unrecognised OS, cannot locate downloads folder")
-            downloads_folder = ""
+            if os.path.exists(downloads_folder):
+                print("Downloads Folder Located")
+
+            elif not os.path.exists(downloads_folder):
+                downloads_folder = str(Path.home() / "Downloads")
+
+            else:
+                print("Unrecognised OS, cannot locate downloads folder")
+                downloads_folder = ""
+
+        elif choice is choice=="y" or choice=="Y":
+
+            downloads_folder=str(os.path.dirname(os.path.abspath(__file__)))+"\Output"
+
+            if os.path.exists(downloads_folder):
+                print("Adding to Output Folder...")
+
+            elif not os.path.exists(downloads_folder):
+                os.makedirs('output')
+
+            else:
+                print("Uknown Error")
 
         return downloads_folder
 

--- a/src/BODSDataExtractor/extractor.py
+++ b/src/BODSDataExtractor/extractor.py
@@ -960,20 +960,11 @@ class TimetableExtractor:
         return self.timetable_dict
 
 
-    def get_user_downloads_folder(self):
-        '''
-        Specify where the output of stop level is saved, within the project folder or in the downloads folder
-        '''
-        
-        question = "Enter 'Y' to save to project folder or 'N' to save to downloads folder: "
-        
-        choice = input(question)
-        while choice not in ['y', 'Y', 'n', 'N']:
-            print('Invalid choice')
-            choice = input(question)
+    def get_user_downloads_folder(self, in_downloads_folder):
         
         
-        if choice =="N" or choice=="n":
+        
+        if in_downloads_folder:
             
             downloads_folder = str(os.path.join(Path.home(), "Downloads"))
             
@@ -987,12 +978,12 @@ class TimetableExtractor:
                 print("Unrecognised OS, cannot locate downloads folder")
                 downloads_folder = ""
             
-        elif choice is choice=="y" or choice=="Y":
+        elif not in_downloads_folder:
             
             downloads_folder=str(os.path.dirname(os.path.abspath(__file__)))+"\Output"
             
             if os.path.exists(downloads_folder):
-                print("Adding to Output Folder...")
+                print("Adding to output Folder...")
             
             elif not os.path.exists(downloads_folder):
                 os.makedirs('output')
@@ -1002,12 +993,12 @@ class TimetableExtractor:
 
         return downloads_folder
 
-    def create_today_folder(self):
+    def create_today_folder(self, in_downloads_folder):
         '''
         Create a folder, named with the days data, so that timetables can be saved locally
         '''
         today = str(date.today())
-        downloads_folder = TimetableExtractor.get_user_downloads_folder(self)
+        downloads_folder = TimetableExtractor.get_user_downloads_folder(self, in_downloads_folder)
 
         # list out the file names in the downloads folder
         files = os.listdir(downloads_folder)
@@ -1077,14 +1068,14 @@ class TimetableExtractor:
         destination = TimetableExtractor.create_today_folder(self)
         self.service_line_extract.to_csv(f'{destination}/service_line_extract.csv', index=False)
 
-    def save_all_timetables_to_csv(self):
+    def save_all_timetables_to_csv(self, in_downloads_folder=True):
 
         '''
         Save all timetables from the timetable_dict attribute as local csv files.
         '''
 
         #create folder to save timetables int and get name of new folder
-        destination = TimetableExtractor.create_today_folder(self)
+        destination = TimetableExtractor.create_today_folder(self, in_downloads_folder)
 
         for k,v in self.timetable_dict.items():
             print (f'writing {k} to csv...')
@@ -1093,7 +1084,8 @@ class TimetableExtractor:
             v.to_csv(f'{destination}/{k}_timetable.csv', index=False)
 
 
-    def save_filtered_timetables_to_csv(self, service_code):
+    def save_filtered_timetables_to_csv(self, service_code, in_downloads_folder):
+        #downloads folder True or false 
 
         '''
         Save a filtered subset of timetables from the timetable_dict attribute as local csv files.
@@ -1104,7 +1096,7 @@ class TimetableExtractor:
         '''
 
         #create folder to save timetables int and get name of new folder
-        destination = TimetableExtractor.create_today_folder(self)
+        destination = TimetableExtractor.create_today_folder(self, in_downloads_folder)
 
 
         filtered_dict = TimetableExtractor.filter_timetable_dict(self, service_code)


### PR DESCRIPTION
Example File

- Looks at the extractor file present in the directory instead of the extractor file published in the latest release
- Fixed Some typos
- in_downloads_folder added as an argument, so user can specify where they want to save the output

Extractor file

- Additional function created to avoid duplicated code add_to_output _folder
- Saves in either output folder or downloads folder within the package

